### PR TITLE
fix: support task map attribute for yolo >= 8.0.44

### DIFF
--- a/tests/test_hf.py
+++ b/tests/test_hf.py
@@ -11,8 +11,14 @@ import os
 hub_id = "ultralyticsplus/yolov8s"
 
 
+# for ultralytics < 8.0.44
 def test_load_from_hub():
     path = download_from_hub(hub_id)
+
+
+# for ultralytics >= 8.0.44
+def test_load_from_hub_yolo_8_0_44():
+    model = YOLO("keremberke/yolov8n-table-extraction")
 
 
 def test_yolo_from_hub():

--- a/ultralyticsplus/__init__.py
+++ b/ultralyticsplus/__init__.py
@@ -1,4 +1,4 @@
 from .hf_utils import download_from_hub, push_to_hfhub
 from .ultralytics_utils import YOLO, postprocess_classify_output, render_result
 
-__version__ = "0.0.29"
+__version__ = "0.1.0"

--- a/ultralyticsplus/ultralytics_utils.py
+++ b/ultralyticsplus/ultralytics_utils.py
@@ -83,12 +83,28 @@ class YOLO(YOLOBase):
         self.task = self.model.args["task"]
         self.overrides = self.model.args
         self._reset_ckpt_args(self.overrides)
-        (
-            self.ModelClass,
-            self.TrainerClass,
-            self.ValidatorClass,
-            self.PredictorClass,
-        ) = self._assign_ops_from_task()
+
+        # for loading a model with ultralytics <8.0.44
+        if hasattr(self, "_assign_ops_from_task"):
+            (
+                self.ModelClass,
+                self.TrainerClass,
+                self.ValidatorClass,
+                self.PredictorClass,
+            ) = self._assign_ops_from_task()
+
+        # for loading a model with ultralytics >=8.0.44
+        else:
+            if self.task not in self.task_map:
+                raise ValueError(
+                    f"Task '{self.task}' not supported. Supported tasks: {list(self.task_map.keys())}"
+                )
+            (
+                self.ModelClass,
+                self.TrainerClass,
+                self.ValidatorClass,
+                self.PredictorClass,
+            ) = self.task_map[self.task]
 
 
 def render_result(


### PR DESCRIPTION
Any model written with  yolo >= 8.0.44 is broken in this library.

this PR fixes it. I have added a test against this